### PR TITLE
Overdue balance: switch to 30-day due basis (invoiceDate+30)

### DIFF
--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -1,0 +1,55 @@
+name: Preview SPA on PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: 'pages-preview'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install deps
+        working-directory: ar-dashboard-spa
+        run: npm install
+      - name: Build
+        working-directory: ar-dashboard-spa
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ar-dashboard-spa/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy Preview to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          preview: true
+      - name: Comment preview URL on PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Preview is ready: ${{ steps.deployment.outputs.page_url }}
+

--- a/ar-dashboard-spa/src/App.tsx
+++ b/ar-dashboard-spa/src/App.tsx
@@ -105,7 +105,7 @@ export default function App() {
       'Average Monthly Purchases (TRY)': 'Total invoiced in the period divided by months since start.',
       'Credit Limit (TRY)': 'Average monthly purchases × risk/term multiplier; rounded to nearest 10,000.',
       'Available Credit (TRY)': 'Credit limit minus current open AR balance; floored at zero.',
-      'Overdue Balance as % of Credit Limit': 'Unpaid balance past due (by term) divided by assigned credit limit.',
+    'Overdue Balance as % of Credit Limit': 'Unpaid balance past due by 30 days from invoice date divided by assigned credit limit.',
       'Customer Risk Rating': 'Composite rating (Good/Average/Poor) based on weighted metrics.'
     },
     tr: {
@@ -121,7 +121,7 @@ export default function App() {
       'Average Monthly Purchases (TRY)': 'Dönemde kesilen toplam fatura tutarı / başlangıçtan bu yana ay sayısı.',
       'Credit Limit (TRY)': 'Aylık ortalama alış × risk/vade katsayısı; 10.000’e yuvarlanır.',
       'Available Credit (TRY)': 'Kredi limiti − cari açık bakiye; sıfırın altına düşmez.',
-      'Overdue Balance as % of Credit Limit': 'Vadesi geçen ödenmemiş bakiye / atanmış kredi limiti.',
+      'Overdue Balance as % of Credit Limit': 'Fatura tarihinden itibaren 30 günü aşan vadesi geçmiş ödenmemiş bakiye / atanmış kredi limiti.',
       'Customer Risk Rating': 'Ağırlıklandırılmış metriklere dayalı birleşik not (İyi/Orta/Zayıf).'
     },
     ar: {
@@ -137,7 +137,7 @@ export default function App() {
       'Average Monthly Purchases (TRY)': 'إجمالي المبالغ المفوترة خلال الفترة ÷ عدد الأشهر منذ البداية.',
       'Credit Limit (TRY)': 'متوسط المشتريات الشهري × معامل حسب المخاطر/المدة؛ يُقرّب لأقرب 10,000.',
       'Available Credit (TRY)': 'حد الائتمان − الرصيد المفتوح الحالي؛ لا يقل عن صفر.',
-      'Overdue Balance as % of Credit Limit': 'الرصيد غير المسدد المتأخر (حسب المدة) ÷ حد الائتمان المخصص.',
+      'Overdue Balance as % of Credit Limit': 'الرصيد غير المسدد المتأخر بعد 30 يومًا من تاريخ الفاتورة ÷ حد الائتمان المخصص.',
       'Customer Risk Rating': 'تصنيف مركب (جيد/متوسط/ضعيف) مبني على مؤشرات موزونة.'
     }
   }

--- a/ar-dashboard-spa/src/lib/analysis.ts
+++ b/ar-dashboard-spa/src/lib/analysis.ts
@@ -616,10 +616,12 @@ export function analyze(invoicesIn: Invoice[], paymentsIn: Payment[], startDate:
   metrics.push({ label: 'Average Days to Settle (Settlement)', value: roundDays(avgDaysToSettleDisplay), assess: assessLower(avgDaysToSettleDisplay, 20, 40) })
   metrics.push({ label: '% of Invoices Settled After Term (Settlement)', value: pctInvoicesSettledAfterTerm, assess: assessLower(pctInvoicesSettledAfterTerm, 0.20, 0.40) })
   metrics.push({ label: 'Customer Risk Rating', value: riskBand, assess: riskBand })
-  // New metric: overdue balance as a percentage of assigned credit limit (term-based overdue)
+  // New metric: overdue balance as a percentage of assigned credit limit (30-day basis)
+  // Business rule: balance is considered closed upon check handover, but
+  // still outstanding until collected; use invoiceDate + 30 days for overdue.
   const overdueOutstandingTerm = unpaid.reduce((s, inv) => {
     const ageDays = Math.floor(((+today - +inv.invoiceDate) / 86400000))
-    return s + ((ageDays > inv.term) ? inv.remaining : 0)
+    return s + ((ageDays > 30) ? inv.remaining : 0)
   }, 0)
   const pctOverdueVsCreditLimit: number | '' = (creditLimit !== '' && (creditLimit as number) > 0)
     ? (overdueOutstandingTerm / (creditLimit as number))


### PR DESCRIPTION
This PR changes the overdue balance calculation to a fixed 30-day basis from invoice date, matching the business rule that receivables are considered closed at check handover but remain outstanding until collected.

Changes:
- SPA analysis: Overdue balance uses ageDays > 30 instead of > invoice term.
- App tooltip texts updated (EN/TR/AR) to reflect 30-day due basis.
- New GitHub Actions workflow to deploy PR Preview to GitHub Pages and comment the preview URL on the PR.

Testing:
- Upload a sample file and compare the "Overdue Balance as % of Credit Limit" metric with main. It should now reflect 30-day overdue basis regardless of term.

Once checks finish, a "github-pages � Preview" deployment will appear with a link for QA.
