### PR TITLE
Secure latest-report API (GIS) + SPA Save/Load

### DIFF
--- a/ar-dashboard-spa/index.html
+++ b/ar-dashboard-spa/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AR Analysis Dashboard</title>
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
This PR introduces:

- GIS ID token verification in Apps Script (Code.js)
- AccessControl + LatestReportsIndex sheets for authZ + index
- Web endpoints: doGet/doPost for latest report
  - Customer key defaults to cell B1 when not supplied (per request)
- SPA: Google Sign-In button, customer input, Save/Load buttons
- Docs: SECURITY-NOTE.md with setup steps

Setup required after merge:
- Apps Script: set OAUTH_CLIENT_IDS to your GIS Web Client ID and deploy Web App
- SPA: configure window.__AR_WEB_APP_URL and window.__AR_GIS_CLIENT_ID or edit constants in App.tsx

Notes:
- No secrets in client; all enforcement server-side.
- Pages Preview workflow will comment a preview URL on this PR once CI completes.